### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/ServoMotor/keywords.txt
+++ b/ServoMotor/keywords.txt
@@ -13,7 +13,7 @@ ServoMotor	KEYWORD1
 #######################################
 attach	KEYWORD2
 roate	KEYWORD2
-readCommandAndRotatre KEYWORD2
+readCommandAndRotatre	KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords